### PR TITLE
feat(ignore-vendor-dir)

### DIFF
--- a/packages/all/index.js
+++ b/packages/all/index.js
@@ -7,4 +7,5 @@ module.exports = {
     '@typescript-eslint/brace-style': ['error', '1tbs'],
     'curly': ['error', 'all'],
   },
+  "ignorePatterns": ['/vendor'],
 };


### PR DESCRIPTION
This PR ignores the `/vendor` directory created by composer when running within our WordPress Bloom environment. 